### PR TITLE
Refactor/#103 setting & login

### DIFF
--- a/feature/login/src/main/java/com/record/login/singup/SignUpScreen.kt
+++ b/feature/login/src/main/java/com/record/login/singup/SignUpScreen.kt
@@ -43,6 +43,8 @@ import com.record.login.singup.screen.NamingScreen
 import com.record.login.singup.screen.PolicyScreen
 import com.record.login.singup.screen.SignUpSuccessScreen
 import com.record.ui.extension.customClickable
+import com.record.ui.lifecycle.LaunchedEffectWithLifecycle
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -74,6 +76,19 @@ fun SignUpRoute(
         }
     }
 
+    LaunchedEffectWithLifecycle {
+        viewModel.sideEffect.collectLatest { sideEffect ->
+            when (sideEffect) {
+                SignUpEffect.ClearFocus -> {
+                    focusManager.clearFocus()
+                }
+                SignUpEffect.NavigateToHome -> {
+                    navigateToHome()
+                }
+            }
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -87,7 +102,7 @@ fun SignUpRoute(
                     endY = columnSize.height.toFloat() * 0.3f,
                 ),
             )
-            .customClickable(rippleEnabled = false) { focusManager.clearFocus() },
+            .customClickable(rippleEnabled = false) { viewModel.clearFocus() },
     ) {
         Box(
             modifier = Modifier
@@ -157,8 +172,8 @@ fun SignUpRoute(
                             ),
                         )
                     }
-                    if (pagerState.currentPage == 2) navigateToHome()
-                    focusManager.clearFocus()
+                    if (pagerState.currentPage == 2) viewModel.navigateToHome()
+                    viewModel.clearFocus()
                     viewModel.navScreen(pagerState.currentPage + 1)
                 },
                 modifier = Modifier

--- a/feature/login/src/main/java/com/record/login/singup/SignUpScreen.kt
+++ b/feature/login/src/main/java/com/record/login/singup/SignUpScreen.kt
@@ -42,6 +42,7 @@ import com.record.designsystem.theme.RecordyTheme
 import com.record.login.singup.screen.NamingScreen
 import com.record.login.singup.screen.PolicyScreen
 import com.record.login.singup.screen.SignUpSuccessScreen
+import com.record.ui.extension.customClickable
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -85,7 +86,8 @@ fun SignUpRoute(
                     startY = columnSize.height.toFloat() * 0f,
                     endY = columnSize.height.toFloat() * 0.3f,
                 ),
-            ),
+            )
+            .customClickable(rippleEnabled = false) { focusManager.clearFocus() },
     ) {
         Box(
             modifier = Modifier

--- a/feature/login/src/main/java/com/record/login/singup/SignUpState.kt
+++ b/feature/login/src/main/java/com/record/login/singup/SignUpState.kt
@@ -20,4 +20,5 @@ data class SignUpState(
 
 sealed interface SignUpEffect : SideEffect {
     data object NavigateToHome : SignUpEffect
+    data object ClearFocus : SignUpEffect
 }

--- a/feature/login/src/main/java/com/record/login/singup/SignUpViewModel.kt
+++ b/feature/login/src/main/java/com/record/login/singup/SignUpViewModel.kt
@@ -90,6 +90,9 @@ class SignUpViewModel @Inject constructor(
                 intent {
                     copy(btnEnable = true)
                 }
+                authRepository.getLocalData().onSuccess {
+                    authRepository.saveLocalData(it.copy(isSignedUp = true))
+                }
             }.onFailure {
             }
         }

--- a/feature/login/src/main/java/com/record/login/singup/SignUpViewModel.kt
+++ b/feature/login/src/main/java/com/record/login/singup/SignUpViewModel.kt
@@ -27,6 +27,14 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
+    fun clearFocus() {
+        postSideEffect(SignUpEffect.ClearFocus)
+    }
+
+    fun navigateToHome() {
+        postSideEffect(SignUpEffect.NavigateToHome)
+    }
+
     fun checkServiceEvent() {
         intent {
             copy(serviceTermsChecked = !serviceTermsChecked)

--- a/feature/login/src/main/java/com/record/login/singup/screen/NamingScreen.kt
+++ b/feature/login/src/main/java/com/record/login/singup/screen/NamingScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -22,7 +22,7 @@ import kotlinx.coroutines.delay
 
 @Composable
 fun NamingScreen(uiState: SignUpState, onTextChangeEvent: (String) -> Unit, onInputComplete: () -> Unit) {
-    var lastInputTime by remember { mutableStateOf(System.currentTimeMillis()) }
+    var lastInputTime by remember { mutableLongStateOf(System.currentTimeMillis()) }
 
     Column(
         modifier = Modifier.fillMaxSize(),

--- a/feature/navigator/src/main/java/com/record/navigator/MainNavigator.kt
+++ b/feature/navigator/src/main/java/com/record/navigator/MainNavigator.kt
@@ -73,7 +73,7 @@ internal class MainNavigator(
 
     fun navigateLogin() {
         navController.navigate(LoginRoute.route) {
-            popUpTo(navController.graph.startDestinationId) {
+            popUpTo(navController.graph.id) {
                 inclusive = true
             }
         }

--- a/feature/setting/src/main/java/com/record/setting/SettingContract.kt
+++ b/feature/setting/src/main/java/com/record/setting/SettingContract.kt
@@ -5,6 +5,10 @@ import com.record.ui.base.UiState
 
 data class SettingState(
     val dialog: SettingDialog = SettingDialog.NONE,
+    val dialogTitle: String = "",
+    val dialogSubTitle: String = "",
+    val negativeButtonLabel: String = "",
+    val positiveButtonLabel: String = "",
 ) : UiState
 
 sealed interface SettingSideEffect : SideEffect {

--- a/feature/setting/src/main/java/com/record/setting/SettingDialog.kt
+++ b/feature/setting/src/main/java/com/record/setting/SettingDialog.kt
@@ -1,7 +1,7 @@
 package com.record.setting
 
-enum class SettingDialog(title: String) {
-    NONE(title = ""),
-    DELETE(title = ""),
-    LOGOUT(title = ""),
+enum class SettingDialog {
+    NONE,
+    DELETE,
+    LOGOUT,
 }

--- a/feature/setting/src/main/java/com/record/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/record/setting/SettingScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -53,39 +52,33 @@ fun SettingRoute(
         }
     }
 
-    if (uiState.dialog == SettingDialog.LOGOUT) {
-        RecordyDialog(
-            graphicAsset = R.drawable.img_alert,
-            title = "로그아웃 하시겠어요?",
-            subTitle = "버튼을 누르면 로그인 페이지로 이동합니다.",
-            negativeButtonLabel = "취소",
-            positiveButtonLabel = "로그아웃",
-            onDismissRequest = { viewModel.dismissDialog() },
-            onPositiveButtonClick = { viewModel.logoutInDialog() },
-        )
-    }
-    if (uiState.dialog == SettingDialog.DELETE) {
-        RecordyDialog(
-            graphicAsset = R.drawable.img_alert,
-            title = "정말 탈퇴하시겠어요?",
-            subTitle = "소중한 기록들이 모두 사라져요.",
-            negativeButtonLabel = "취소",
-            positiveButtonLabel = "탈퇴",
-            onDismissRequest = { viewModel.dismissDialog() },
-            onPositiveButtonClick = { viewModel.deleteInDialog() },
-        )
-    }
-    SettingScreen(padding, modifier, viewModel::logout, viewModel::delete)
+    SettingScreen(padding, modifier, uiState, viewModel::logout, viewModel::delete, viewModel::dismissDialog, viewModel::eventDialog)
 }
 
 @Composable
 fun SettingScreen(
     padding: PaddingValues = PaddingValues(),
     modifier: Modifier = Modifier,
+    uiState: SettingState,
     logoutEvent: () -> Unit,
     deleteEvent: () -> Unit,
+    dismissDialog: () -> Unit,
+    eventDialog: () -> Unit,
 ) {
     val context = LocalContext.current
+
+    if (uiState.dialog != SettingDialog.NONE) {
+        RecordyDialog(
+            graphicAsset = R.drawable.img_alert,
+            title = uiState.dialogTitle,
+            subTitle = uiState.dialogSubTitle,
+            negativeButtonLabel = uiState.negativeButtonLabel,
+            positiveButtonLabel = uiState.positiveButtonLabel,
+            onDismissRequest = { dismissDialog() },
+            onPositiveButtonClick = { eventDialog() },
+        )
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -110,18 +103,27 @@ fun SettingScreen(
             },
         )
 
-        SettingButtonWithIcon(text = "서비스 이용약관", onClickEvent = {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://bohyunnkim.notion.site/e5c0a49d73474331a21b1594736ee0df?pvs=4"))
-            context.startActivity(intent)
-        },)
-        SettingButtonWithIcon(text = "개인정보 취급취침", onClickEvent = {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://bohyunnkim.notion.site/c2bdf3572df1495c92aedd0437158cf0"))
-            context.startActivity(intent)
-        },)
-        SettingButtonWithIcon(text = "문의", onClickEvent = {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://bohyunnkim.notion.site/46bdd724bf734cf79d34142a03ad52bc?pvs=4"))
-            context.startActivity(intent)
-        },)
+        SettingButtonWithIcon(
+            text = "서비스 이용약관",
+            onClickEvent = {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://bohyunnkim.notion.site/e5c0a49d73474331a21b1594736ee0df?pvs=4"))
+                context.startActivity(intent)
+            },
+        )
+        SettingButtonWithIcon(
+            text = "개인정보 취급취침",
+            onClickEvent = {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://bohyunnkim.notion.site/c2bdf3572df1495c92aedd0437158cf0"))
+                context.startActivity(intent)
+            },
+        )
+        SettingButtonWithIcon(
+            text = "문의",
+            onClickEvent = {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://bohyunnkim.notion.site/46bdd724bf734cf79d34142a03ad52bc?pvs=4"))
+                context.startActivity(intent)
+            },
+        )
         Spacer(modifier = Modifier.height(12.dp))
         Spacer(
             modifier = Modifier
@@ -153,18 +155,19 @@ fun SettingScreen(
 
 @Composable
 fun SettingButtonWithIcon(
-    modifier: Modifier = Modifier
-        .height(48.dp),
+    modifier: Modifier = Modifier,
     text: String = "커뮤니티 가이드라인",
     onClickEvent: () -> Unit = {},
 ) {
-    Row(modifier = modifier.customClickable(rippleEnabled = false, onClick = onClickEvent), verticalAlignment = Alignment.CenterVertically) {
+    Row(
+        modifier = modifier.customClickable(rippleColor = RecordyTheme.colors.white, onClick = onClickEvent),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         Text(
             text = text,
             modifier = modifier
-                .fillMaxHeight()
                 .padding(start = 16.dp)
-                .padding(vertical = 12.dp),
+                .padding(vertical = 16.dp),
             style = RecordyTheme.typography.body1M,
             color = RecordyTheme.colors.gray01,
             textAlign = TextAlign.Center,
@@ -173,8 +176,7 @@ fun SettingButtonWithIcon(
         Icon(
             painter = painterResource(id = R.drawable.ic_angle_right_24),
             modifier = modifier
-                .padding(end = 16.dp)
-                .padding(vertical = 16.dp),
+                .padding(16.dp),
             contentDescription = "",
             tint = RecordyTheme.colors.gray03,
         )
@@ -183,8 +185,7 @@ fun SettingButtonWithIcon(
 
 @Composable
 fun SettingButton(
-    modifier: Modifier = Modifier
-        .height(48.dp),
+    modifier: Modifier = Modifier,
     text: String = "로그인 연동",
     kakao: Boolean = false,
     onClickEvent: () -> Unit = {},
@@ -192,15 +193,15 @@ fun SettingButton(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .customClickable(rippleEnabled = false, onClick = onClickEvent),
+            .customClickable(rippleColor = RecordyTheme.colors.white, onClick = onClickEvent),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = text,
             modifier = modifier
-                .fillMaxHeight()
                 .padding(start = 16.dp)
-                .padding(vertical = 12.dp),
+                .padding(vertical = 16.dp)
+                .align(Alignment.CenterVertically),
             style = RecordyTheme.typography.body1M,
             color = RecordyTheme.colors.gray01,
             textAlign = TextAlign.Center,
@@ -222,6 +223,12 @@ fun SettingButton(
 @Composable
 fun PreviewSettingScreen() {
     RecordyTheme {
-        SettingScreen(logoutEvent = {}, deleteEvent = {})
+        SettingScreen(
+            uiState = SettingState(),
+            logoutEvent = {},
+            deleteEvent = {},
+            dismissDialog = {},
+            eventDialog = {},
+        )
     }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- login : signup 시 자동로그인 설정
- login : signup sideeffect
- login : singup 화면에 텍스트 입력 포커싱 clear 
- setting:  뷰 변경
     - 텍스트 ,아이콘 위치 조정
     - ripple 효과 추가
- setting: dialog 리팩토링  (uistate 사용)
- setting: 더이상 로그인 화면으로 이동시 뒤로가기를 통해 돌아오지 않습니다.

🌱 PR 포인트


## 📸 스크린샷
이전과 동일

## 📮 관련 이슈
- Resolved: #103 
